### PR TITLE
Add rank change indicators to leaderboard

### DIFF
--- a/src/html/panel.html
+++ b/src/html/panel.html
@@ -148,6 +148,23 @@
 
             }
 
+            .rank-delta {
+                margin-left: auto;
+                font-weight: bold;
+            }
+
+            .rank-delta.up {
+                color: #4CAF50;
+            }
+
+            .rank-delta.down {
+                color: #F44336;
+            }
+
+            .rank-delta.same {
+                color: #AAA;
+            }
+
             .ellipsis {
                 text-align: center;
                 color: #666;


### PR DESCRIPTION
## Summary
- persist previous ranks using global state
- show rank delta arrows on leaderboard rows
- display user rank changes in profile when outside top 10

## Testing
- `npm run lint`
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68556b09b558832daffac1e6c7355d12